### PR TITLE
feat: gather and show query loaded-nanopub checksum

### DIFF
--- a/src/main/java/ch/tkuhn/nanopub/monitor/CsvTable.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/CsvTable.java
@@ -41,7 +41,7 @@ public class CsvTable implements SerializableSupplier<IResource> {
     public IResource get() {
         StringWriter sw = new StringWriter();
         CSVWriter w = new CSVWriter(sw);
-        w.writeNext(new String[]{"URL", "Type", "Version", "Test Instance", "Status", "Current Setting", "Original Setting", "Trust State Hash", "Hash Group", "Nanopub Count", "OK Ratio", "Resp Time", "Dist", "Last Seen OK", "IP Address", "Server Location"});
+        w.writeNext(new String[]{"URL", "Type", "Version", "Test Instance", "Status", "Current Setting", "Original Setting", "Trust State Hash", "Hash Group", "Loaded Nanopub Checksum", "Nanopub Count", "OK Ratio", "Resp Time", "Dist", "Last Seen OK", "IP Address", "Server Location"});
         ServerList sl = ServerList.get();
         for (ServerData sd : sl.getSortedServerData()) {
             Float sr = sd.getSuccessRatio();
@@ -50,6 +50,7 @@ public class CsvTable implements SerializableSupplier<IResource> {
             ServerIpInfo i = sd.getIpInfo();
             String hash = sd.getTrustStateHash();
             String group = sl.getHashGroupLabel(sd);
+            String checksum = sd.getLoadedNanopubChecksum();
             Long npc = sd.getNanopubCount();
             w.writeNext(new String[]{
                     sd.getServiceId(),
@@ -61,6 +62,7 @@ public class CsvTable implements SerializableSupplier<IResource> {
                     (sd.getOriginalSetting() == null ? "" : sd.getOriginalSetting()),
                     (hash == null ? "" : hash),
                     (group == null ? "" : group),
+                    (checksum == null ? "" : checksum),
                     (npc == null ? "" : npc.toString()),
                     (sr == null ? "" : sr + ""),
                     (rt == null ? "" : rt + ""),

--- a/src/main/java/ch/tkuhn/nanopub/monitor/JsonStatus.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/JsonStatus.java
@@ -51,6 +51,7 @@ public class JsonStatus implements SerializableSupplier<IResource> {
             s.put("originalSetting", sd.getOriginalSetting());
             s.put("trustStateHash", sd.getTrustStateHash());
             s.put("hashGroup", sl.getHashGroupLabel(sd));
+            s.put("loadedNanopubChecksum", sd.getLoadedNanopubChecksum());
             s.put("nanopubCount", sd.getNanopubCount());
             s.put("okRatio", sd.getSuccessRatio());
             s.put("respTimeMs", sd.getAvgResponseTimeInMs());

--- a/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.html
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.html
@@ -29,7 +29,7 @@
       <th>Type</th>
       <th>Version</th>
       <th>Status</th>
-      <th>Setting / Trust Hash</th>
+      <th>Setting / Checksum</th>
       <th>Nanopubs</th>
       <th>OK Ratio</th>
       <th>Resp Time (Dist)</th>

--- a/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.java
@@ -122,13 +122,16 @@ public class MonitorPage extends WebPage {
     }
 
     /**
-     * Format the trust hash table cell, combining setting and hash:
+     * Format the setting/checksum table cell, combining setting and hash:
      *   "<setting> / <hash> (<group>)"
      * with "<origSetting> → <currentSetting> / ..." when the setting was changed at runtime.
+     * The hash is the registry trust state hash, falling back to the query instance's
+     * loaded-nanopub checksum (query instances have no setting and no consensus group).
      * Returns "" if neither a setting nor a hash is known.
      */
     static String formatTrustHashCell(ServerData d, String groupLabel) {
         String hashShort = d.getTrustStateHashShort();
+        if (hashShort.isEmpty()) hashShort = d.getLoadedNanopubChecksumShort();
         String current = d.getCurrentSetting();
         String original = d.getOriginalSetting();
         if (hashShort.isEmpty() && current == null) return "";

--- a/src/main/java/ch/tkuhn/nanopub/monitor/ServerData.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/ServerData.java
@@ -35,6 +35,7 @@ public class ServerData implements Serializable {
     private String distanceString = null;
     private long totalResponseTime = 0;
     private String trustStateHash;
+    private String loadedNanopubChecksum;
     private String currentSetting;
     private String originalSetting;
     private Long nanopubCount;
@@ -270,8 +271,47 @@ public class ServerData implements Serializable {
      * @return the short hash, or ""
      */
     public String getTrustStateHashShort() {
-        if (trustStateHash == null || trustStateHash.length() < 12) return trustStateHash == null ? "" : trustStateHash;
-        return trustStateHash.substring(0, 12);
+        return shortHash(trustStateHash);
+    }
+
+    /**
+     * Get the checksum of loaded nanopubs last reported by this server, or null if unknown
+     * (e.g. for non-query types, or if the server has not yet been scanned). Reported by
+     * nanopub-query instances via the {@code Nanopub-Query-Loaded-Nanopub-Checksum} header.
+     *
+     * @return the loaded-nanopub checksum, or null
+     */
+    public String getLoadedNanopubChecksum() {
+        return loadedNanopubChecksum;
+    }
+
+    /**
+     * Set the checksum of loaded nanopubs for this server.
+     *
+     * @param checksum the loaded-nanopub checksum (may be null)
+     */
+    public void setLoadedNanopubChecksum(String checksum) {
+        this.loadedNanopubChecksum = checksum;
+    }
+
+    /**
+     * Get a short prefix of the loaded-nanopub checksum suitable for display, or "" if unknown.
+     *
+     * @return the short checksum, or ""
+     */
+    public String getLoadedNanopubChecksumShort() {
+        return shortHash(loadedNanopubChecksum);
+    }
+
+    /**
+     * Short prefix of a hash/checksum string for compact display, or "" if null.
+     *
+     * @param hash the hash or checksum
+     * @return the first 12 characters, the whole value if shorter, or ""
+     */
+    private static String shortHash(String hash) {
+        if (hash == null) return "";
+        return hash.length() < 12 ? hash : hash.substring(0, 12);
     }
 
     /**

--- a/src/main/java/ch/tkuhn/nanopub/monitor/ServerList.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/ServerList.java
@@ -104,6 +104,36 @@ public class ServerList implements Serializable {
             if (h == null) continue;
             counts.merge(h, 1, Integer::sum);
         }
+        return majorityKey(counts);
+    }
+
+    /**
+     * Get the loaded-nanopub checksum reported by the largest number of query instances in the
+     * given test cohort. Used as the consensus value for query instances: those with the same
+     * test-instance status but a different checksum are flagged as outliers. Query instances do
+     * not expose a setting, so consensus is scoped by test-instance status instead — test and
+     * non-test instances load from different networks, so comparing their checksums across that
+     * boundary is not meaningful.
+     *
+     * @param testInstance whether to consider the test cohort (true) or the non-test cohort (false)
+     * @return the majority loaded-nanopub checksum for the cohort, or null if none
+     */
+    public String getMajorityLoadedNanopubChecksum(boolean testInstance) {
+        Map<String, Integer> counts = new HashMap<>();
+        for (ServerData sd : servers.values()) {
+            if (!sd.hasServiceTypePrefix(NanopubService.NANOPUB_QUERY_TYPE_IRI)) continue;
+            if (sd.isTestInstance() != testInstance) continue;
+            String h = sd.getLoadedNanopubChecksum();
+            if (h == null) continue;
+            counts.merge(h, 1, Integer::sum);
+        }
+        return majorityKey(counts);
+    }
+
+    /**
+     * Return the key with the strictly highest count in the given map, or null if the map is empty.
+     */
+    private static String majorityKey(Map<String, Integer> counts) {
         String majority = null;
         int best = 0;
         for (Map.Entry<String, Integer> e : counts.entrySet()) {
@@ -116,23 +146,34 @@ public class ServerList implements Serializable {
     }
 
     /**
-     * Classify a registry's trust state hash against the consensus of its setting cohort.
-     * Returns "consensus" if it matches the majority for the same setting, "outlier" if it
-     * differs, or null if the server is not a registry, has not reported a hash, or has not
-     * reported a setting.
+     * Classify a server's reported hash against the consensus of its cohort. For registries, the
+     * hash is the trust state hash and the cohort is registries running the same setting; for query
+     * instances, the hash is the loaded-nanopub checksum and the cohort is query instances with the
+     * same test-instance status. Returns "consensus" if it matches the cohort majority, "outlier"
+     * if it differs, or null if the server reports no comparable hash (or, for registries, no
+     * setting).
      *
      * @param sd the server data
      * @return "consensus", "outlier", or null
      */
     public String getHashGroupLabel(ServerData sd) {
-        if (!sd.hasServiceTypePrefix(NanopubService.NANOPUB_REGISTRY_TYPE_IRI)) return null;
-        String h = sd.getTrustStateHash();
-        if (h == null) return null;
-        String setting = sd.getCurrentSetting();
-        if (setting == null) return null;
-        String majority = getMajorityTrustStateHashForSetting(setting);
-        if (majority == null) return null;
-        return h.equals(majority) ? "consensus" : "outlier";
+        if (sd.hasServiceTypePrefix(NanopubService.NANOPUB_REGISTRY_TYPE_IRI)) {
+            String h = sd.getTrustStateHash();
+            if (h == null) return null;
+            String setting = sd.getCurrentSetting();
+            if (setting == null) return null;
+            String majority = getMajorityTrustStateHashForSetting(setting);
+            if (majority == null) return null;
+            return h.equals(majority) ? "consensus" : "outlier";
+        }
+        if (sd.hasServiceTypePrefix(NanopubService.NANOPUB_QUERY_TYPE_IRI)) {
+            String h = sd.getLoadedNanopubChecksum();
+            if (h == null) return null;
+            String majority = getMajorityLoadedNanopubChecksum(sd.isTestInstance());
+            if (majority == null) return null;
+            return h.equals(majority) ? "consensus" : "outlier";
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/ch/tkuhn/nanopub/monitor/ServerScanner.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/ServerScanner.java
@@ -364,6 +364,7 @@ public class ServerScanner implements ICode {
                     } else {
                         d.setVersion(headerValue(resp, "Nanopub-Query-Version"));
                         d.setNanopubCount(parseLongOrNull(headerValue(resp, "Nanopub-Query-Loaded-Nanopub-Count")));
+                        d.setLoadedNanopubChecksum(headerValue(resp, "Nanopub-Query-Loaded-Nanopub-Checksum"));
                         d.setTestInstance("true".equalsIgnoreCase(headerValue(resp, "Nanopub-Query-Registry-Test-Instance")));
                         String headerStatus = headerValue(resp, "Nanopub-Query-Status");
                         if (headerStatus == null || !headerStatus.equalsIgnoreCase("READY")) {


### PR DESCRIPTION
## Summary

The latest nanopub-query instances expose a `Nanopub-Query-Loaded-Nanopub-Checksum` HTTP header. This PR gathers it and surfaces it in the existing table column, which is renamed **"Setting / Checksum"** (it now carries both the registry trust state hash and the query loaded-nanopub checksum).

- **Scanner** (`ServerScanner`): reads `Nanopub-Query-Loaded-Nanopub-Checksum` in the query branch.
- **Data model** (`ServerData`): new `loadedNanopubChecksum` field, kept distinct from `trustStateHash` so the CSV/JSON exports stay semantically accurate (registries report a *trust state hash*; query instances report a *loaded-nanopub checksum*). Shared `shortHash()` helper for the 12-char display prefix.
- **UI** (`MonitorPage` / `MonitorPage.html`): cell falls back to the checksum when no trust hash is present; column header renamed to "Setting / Checksum".
- **Consensus/outlier labeling** (`ServerList`): query instances now get `(consensus)` / red `(outlier)` labels like registries. Registry consensus is scoped per setting; query consensus is scoped by **test vs non-test** instance status, since query instances expose no setting (test and non-test load from different networks). Shared `majorityKey()` helper.
- **Exports** (`CsvTable` / `JsonStatus`): added a dedicated `Loaded Nanopub Checksum` / `loadedNanopubChecksum` field; the existing `hashGroup` field is now populated for query rows too.

## Notes

- **Cohort scoping limitation:** query consensus groups by test-status only. If multiple production query instances load from registries with *different* settings, they share one cohort and the minority shows as "outlier" — the finest grouping the available headers allow.
- **Tie-breaking:** `majorityKey` requires a strict maximum, matching existing registry behavior (two equally-sized groups → no majority → all flagged "outlier").

🤖 Generated with [Claude Code](https://claude.com/claude-code)