### PR TITLE
feat: reduce scan interval to 10s and throttle ip-api.com lookups

### DIFF
--- a/src/main/java/ch/tkuhn/nanopub/monitor/ServerData.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/ServerData.java
@@ -13,8 +13,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Data about a nanopublication server, including its service description, IP-based geolocation info,
@@ -51,10 +51,12 @@ public class ServerData implements Serializable {
      * @param service the nanopublication service
      * @param info    optional additional server info (may be null)
      */
+    /** Query ip-api.com for a given host at most once per this interval (10 minutes). */
+    private static final long IP_INFO_TTL_MS = 10 * 60 * 1000;
+
     public ServerData(NanopubService service, Object info) {
         this.service = service;
         update(info);
-        getIpInfo();
     }
 
     /**
@@ -70,13 +72,8 @@ public class ServerData implements Serializable {
     }
 
     private void ensureIpInfoLoaded() {
-        if (ipInfo != null && ipInfo != ServerIpInfo.empty) {
-            // already loaded
-            return;
-        }
-        long now = System.currentTimeMillis();
-        if (now - lastIpInfoRetrieval > 1000 * 60 * 10) {
-            // retry every 10 minutes
+        if (ipInfo == null || System.currentTimeMillis() - lastIpInfoRetrieval >= IP_INFO_TTL_MS) {
+            // (re)load at most every 10 minutes; the actual ip-api.com call is throttled in fetchIpInfo
             loadIpInfo();
         }
     }
@@ -136,9 +133,7 @@ public class ServerData implements Serializable {
      * @return the ServerIpInfo object (never null; may be empty)
      */
     public ServerIpInfo getIpInfo() {
-        if (ipInfo == null) {
-            loadIpInfo();
-        }
+        ensureIpInfoLoaded();
         return ipInfo;
     }
 
@@ -458,20 +453,32 @@ public class ServerData implements Serializable {
         return (int) calculateDistance(sLat, sLng, monitorIpInfo.getLatitude(), monitorIpInfo.getLongitude());
     }
 
-    private static Map<String, ServerIpInfo> ipInfoMap = new HashMap<>();
+    private static final Map<String, ServerIpInfo> ipInfoMap = new ConcurrentHashMap<>();
+    private static final Map<String, Long> ipInfoFetchedAt = new ConcurrentHashMap<>();
 
     /**
      * Fetch IP-based geolocation info for the given host using the ip-api.com service.
+     * <p>
+     * The result is cached per host and the remote service is queried at most once per host
+     * per {@link #IP_INFO_TTL_MS} (10 minutes). The attempt timestamp is recorded up front, so
+     * a failed lookup (e.g. when ip-api.com rate-limits us) is throttled the same way and is not
+     * retried on every scan; within the throttle window the last known value is returned, or
+     * {@link ServerIpInfo#empty} if none was obtained yet.
      *
      * @param host the hostname or IP address to look up
-     * @return the ServerIpInfo object with geolocation data
+     * @return the ServerIpInfo object with geolocation data (never null)
      * @throws IOException        if an I/O error occurs
      * @throws URISyntaxException if the constructed URI is invalid
      */
     public static ServerIpInfo fetchIpInfo(String host) throws IOException, URISyntaxException {
         if (!MonitorConf.get().isGeoIpInfoEnabled()) return ServerIpInfo.empty;
-        if (ipInfoMap.containsKey(host)) return ipInfoMap.get(host);
-        ServerIpInfo serverIpInfo = null;
+        Long fetchedAt = ipInfoFetchedAt.get(host);
+        if (fetchedAt != null && System.currentTimeMillis() - fetchedAt < IP_INFO_TTL_MS) {
+            ServerIpInfo cached = ipInfoMap.get(host);
+            return cached == null ? ServerIpInfo.empty : cached;
+        }
+        ipInfoFetchedAt.put(host, System.currentTimeMillis());
+        ServerIpInfo serverIpInfo;
         URL geoipUrl = new URI("http://ip-api.com/json/" + host).toURL();
         HttpURLConnection con = null;
         try {

--- a/src/main/resources/ch/tkuhn/nanopub/monitor/conf.properties
+++ b/src/main/resources/ch/tkuhn/nanopub/monitor/conf.properties
@@ -4,7 +4,7 @@
 # 'local.conf.properties' (not under version control).
 
 # Scan frequency in seconds:
-scan-freq=120
+scan-freq=10
 
 # Number of parallel workers used to test servers in each scan:
 scan-threads=8


### PR DESCRIPTION
## Summary

- **Scan interval:** lowered the default `scan-freq` from `120` to `10` seconds for more frequent status updates.
- **Geo-IP throttling:** decoupled ip-api.com lookups from scan frequency so faster scans don't increase geo-IP traffic. Each host is now queried **at most once per 10 minutes**.

## Details

In `ServerData`:
- `fetchIpInfo` records the attempt timestamp **up front**, so a *failed* lookup (e.g. when ip-api.com rate-limits us) is throttled on the same 10-minute window instead of being retried on the next render. Previously failures weren't cached at all.
- The per-host caches (`ipInfoMap` + new `ipInfoFetchedAt`) are now `ConcurrentHashMap`, since with 10s scans the servers are probed across 8 worker threads concurrently.
- `getIpInfo` / `ensureIpInfoLoaded` now share a single gate (`IP_INFO_TTL_MS`) and refresh on that 10-minute cadence.

The scan loop itself never calls ip-api.com (geo lookups happen lazily on access and are cached), so the faster scan cadence does not add geo-IP requests.

## Notes

- The scan interval is read once when the daemon starts, so a running instance picks up the new value only after a restart (or its 10-minute liveness auto-restart).
- `scan-freq` is the *target* interval; a scan that takes longer than that because of slow/unreachable servers (up to a 15s socket timeout each) will stretch the actual update cadence accordingly.
- Heads-up unrelated to the diff: this is a 12x increase in probe volume against every monitored server. Can be overridden locally via `local.conf.properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)