### PR TITLE
feat(scanner): show Nanodash version from Nanodash-Version header

### DIFF
--- a/src/main/java/ch/tkuhn/nanopub/monitor/ServerScanner.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/ServerScanner.java
@@ -405,6 +405,25 @@ public class ServerScanner implements ICode {
                     logger.error("Test failed. Exception: {}", ex.getMessage());
                     d.reportTestFailure("INACCESSIBLE");
                 }
+            } else if (d.hasServiceTypePrefix(NanopubService.NANODASH_TYPE_IRI)) {
+                logger.info("Probing Nanodash status at {}...", d.getServiceId());
+                try {
+                    HttpGet get = new HttpGet(d.getServiceId());
+                    StopWatch watch = new StopWatch();
+                    watch.start();
+                    HttpResponse resp = c.execute(get);
+                    watch.stop();
+                    if (!wasSuccessful(resp)) {
+                        logger.info("Test failed. HTTP code {}", resp.getStatusLine().getStatusCode());
+                        d.reportTestFailure("DOWN");
+                    } else {
+                        d.setVersion(headerValue(resp, "Nanodash-Version"));
+                        d.reportTestSuccess(watch.getTime());
+                    }
+                } catch (Exception ex) {
+                    logger.error("Test failed. Exception: {}", ex.getMessage());
+                    d.reportTestFailure("INACCESSIBLE");
+                }
             } else {
                 logger.info("Trying to access {}...", d.getServiceId());
                 try {


### PR DESCRIPTION
## Summary

Nanodash services previously matched none of the type-specific scanner branches and fell through to the generic probe, which only checks reachability and reports no version (the "Version" column stayed blank). This adds a dedicated Nanodash branch that reads the `Nanodash-Version` HTTP header and surfaces it like the registry/query/server versions.

## Details

- Matches via `hasServiceTypePrefix(NANODASH_TYPE_IRI)`, consistent with the registry/query branches and the existing label/color logic.
- Reads `headerValue(resp, "Nanodash-Version")` on a successful response and reports OK/DOWN/INACCESSIBLE like the other branches.

## Verification

Checked a live Nanodash instance: the root URL returns a `302` carrying `Nanodash-Version: 4.28.1-SNAPSHOT`, and the header is also present on the final `200` after the redirect. Since our `HttpClient` follows redirects by default, the header is on the response we read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)