### PR TITLE
feat(monitor): flag query instances that fall behind their own registry

### DIFF
--- a/src/main/java/ch/tkuhn/nanopub/monitor/CsvTable.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/CsvTable.java
@@ -41,7 +41,7 @@ public class CsvTable implements SerializableSupplier<IResource> {
     public IResource get() {
         StringWriter sw = new StringWriter();
         CSVWriter w = new CSVWriter(sw);
-        w.writeNext(new String[]{"URL", "Type", "Version", "Test Instance", "Status", "Current Setting", "Original Setting", "Trust State Hash", "Hash Group", "Loaded Nanopub Checksum", "Nanopub Count", "OK Ratio", "Resp Time", "Dist", "Last Seen OK", "IP Address", "Server Location"});
+        w.writeNext(new String[]{"URL", "Type", "Version", "Test Instance", "Status", "Current Setting", "Original Setting", "Trust State Hash", "Hash Group", "Loaded Nanopub Checksum", "Nanopub Count", "Registry Nanopub Count", "Sync Lag", "Loader Age (s)", "OK Ratio", "Resp Time", "Dist", "Last Seen OK", "IP Address", "Server Location"});
         ServerList sl = ServerList.get();
         for (ServerData sd : sl.getSortedServerData()) {
             Float sr = sd.getSuccessRatio();
@@ -52,6 +52,9 @@ public class CsvTable implements SerializableSupplier<IResource> {
             String group = sl.getHashGroupLabel(sd);
             String checksum = sd.getLoadedNanopubChecksum();
             Long npc = sd.getNanopubCount();
+            Long rnpc = sd.getRegistryNanopubCount();
+            Long lag = sd.getSyncLag();
+            Long loaderAge = sd.getLoaderLastSuccessAgeSeconds();
             w.writeNext(new String[]{
                     sd.getServiceId(),
                     sd.getService().getTypeIri().stringValue(),
@@ -64,6 +67,9 @@ public class CsvTable implements SerializableSupplier<IResource> {
                     (group == null ? "" : group),
                     (checksum == null ? "" : checksum),
                     (npc == null ? "" : npc.toString()),
+                    (rnpc == null ? "" : rnpc.toString()),
+                    (lag == null ? "" : lag.toString()),
+                    (loaderAge == null ? "" : loaderAge.toString()),
                     (sr == null ? "" : sr + ""),
                     (rt == null ? "" : rt + ""),
                     (dist == null ? "" : dist + ""),

--- a/src/main/java/ch/tkuhn/nanopub/monitor/JsonStatus.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/JsonStatus.java
@@ -53,6 +53,9 @@ public class JsonStatus implements SerializableSupplier<IResource> {
             s.put("hashGroup", sl.getHashGroupLabel(sd));
             s.put("loadedNanopubChecksum", sd.getLoadedNanopubChecksum());
             s.put("nanopubCount", sd.getNanopubCount());
+            s.put("registryNanopubCount", sd.getRegistryNanopubCount());
+            s.put("syncLag", sd.getSyncLag());
+            s.put("loaderAgeSeconds", sd.getLoaderLastSuccessAgeSeconds());
             s.put("okRatio", sd.getSuccessRatio());
             s.put("respTimeMs", sd.getAvgResponseTimeInMs());
             s.put("distanceKm", sd.getDistanceInKm());

--- a/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.html
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.html
@@ -31,6 +31,8 @@
       <th>Status</th>
       <th>Setting / Checksum</th>
       <th>Nanopubs</th>
+      <th>Sync</th>
+      <th>Loader</th>
       <th>OK Ratio</th>
       <th>Resp Time (Dist)</th>
       <th>Last Seen OK</th>
@@ -44,6 +46,8 @@
       <td><span wicket:id="status"></span></td>
       <td><span wicket:id="trusthash"></span></td>
       <td><span wicket:id="nanopubcount"></span></td>
+      <td><span wicket:id="synclag"></span></td>
+      <td><span wicket:id="loaderage"></span></td>
       <td><span wicket:id="successratio"></span></td>
       <td><span wicket:id="resptime"></span></td>
       <td><span wicket:id="lastseen"></span></td>

--- a/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/MonitorPage.java
@@ -115,6 +115,21 @@ public class MonitorPage extends WebPage {
                 }
                 item.add(trustHashLabel);
                 item.add(new Label("nanopubcount", d.getNanopubCountString()));
+                // Any non-zero lag is worth showing in red: unlike the checksum outlier,
+                // this is measured against the instance's own registry, so it means the
+                // instance is genuinely missing nanopubs rather than merely disagreeing
+                // with its peers.
+                Label syncLagLabel = new Label("synclag", d.getSyncLagString());
+                if (d.isBehind()) {
+                    syncLagLabel.add(new AttributeModifier("style", "color: red"));
+                }
+                item.add(syncLagLabel);
+                Label loaderAgeLabel = new Label("loaderage", d.getLoaderAgeString());
+                Long loaderAge = d.getLoaderLastSuccessAgeSeconds();
+                if (loaderAge != null && loaderAge > SyncHealth.LOADER_STALL_SECONDS) {
+                    loaderAgeLabel.add(new AttributeModifier("style", "color: red"));
+                }
+                item.add(loaderAgeLabel);
                 item.add(new Label("successratio", d.getSuccessRatioString()));
                 item.add(new Label("resptime", d.getAvgResponseTimeString() + " (" + d.getDistanceString() + ")"));
                 item.add(new Label("lastseen", formatDate(d.getLastSeenDate())));

--- a/src/main/java/ch/tkuhn/nanopub/monitor/ServerData.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/ServerData.java
@@ -39,6 +39,9 @@ public class ServerData implements Serializable {
     private String currentSetting;
     private String originalSetting;
     private Long nanopubCount;
+    private Long registryNanopubCount;
+    private Long loaderLastSuccessAgeSeconds;
+    private Long behindSinceMs;
     private boolean testInstance;
     private String version;
 
@@ -383,6 +386,110 @@ public class ServerData implements Serializable {
     public String getNanopubCountString() {
         if (nanopubCount == null) return "";
         return String.format("%,d", nanopubCount);
+    }
+
+    /**
+     * Record the sync-health headers from a nanopub-query scan.
+     *
+     * <p>Also maintains the "behind since" mark that {@link #isSyncStalled()} reads, so a
+     * momentary lag between an instance's registry poll and its batch landing is not
+     * reported as a stall. The mark clears as soon as the instance is level again.
+     *
+     * @param registryCount    nanopubs the instance's own registry reports holding, or null
+     * @param loaderAgeSeconds seconds since the instance's loader last completed a tick, or
+     *                         null when the instance does not report it
+     */
+    public void updateSyncHealth(Long registryCount, Long loaderAgeSeconds) {
+        this.registryNanopubCount = registryCount;
+        this.loaderLastSuccessAgeSeconds = loaderAgeSeconds;
+        Long lag = getSyncLag();
+        if (lag == null || lag == 0L) {
+            behindSinceMs = null;
+        } else if (behindSinceMs == null) {
+            behindSinceMs = System.currentTimeMillis();
+        }
+    }
+
+    /**
+     * Get the nanopub count reported by this instance's own registry, or null if unknown
+     * (non-query types, or not yet scanned). Reported via the
+     * {@code Nanopub-Query-Registry-Nanopub-Count} header.
+     *
+     * @return the registry's nanopub count, or null
+     */
+    public Long getRegistryNanopubCount() {
+        return registryNanopubCount;
+    }
+
+    /**
+     * Get the seconds since this instance's loader last completed a tick, or null if
+     * unknown. Reported via the {@code Nanopub-Query-Loader-Last-Success-Age-Seconds}
+     * header; instances predating that header simply leave this empty.
+     *
+     * @return the loader age in seconds, or null
+     */
+    public Long getLoaderLastSuccessAgeSeconds() {
+        return loaderLastSuccessAgeSeconds;
+    }
+
+    /**
+     * How far this instance trails its own registry, or null if either count is unknown.
+     *
+     * @return the lag in nanopubs, or null
+     */
+    public Long getSyncLag() {
+        return SyncHealth.lag(registryNanopubCount, nanopubCount);
+    }
+
+    /**
+     * Get the sync lag as a display string, or "" if unknown.
+     *
+     * @return "in sync", "N behind", or ""
+     */
+    public String getSyncLagString() {
+        return SyncHealth.formatLag(getSyncLag());
+    }
+
+    /**
+     * Get the loader age as a display string, or "" if unknown.
+     *
+     * @return e.g. "2s ago", "2h 04m ago", or ""
+     */
+    public String getLoaderAgeString() {
+        return SyncHealth.formatAge(loaderLastSuccessAgeSeconds);
+    }
+
+    /**
+     * Whether this instance is behind its registry at all, however briefly.
+     *
+     * @return true if the lag is known and non-zero
+     */
+    public boolean isBehind() {
+        Long lag = getSyncLag();
+        return lag != null && lag > 0L;
+    }
+
+    /**
+     * Whether this instance is reachable but has stopped keeping up with its registry.
+     *
+     * @return true if it has been out of sync long enough to report
+     */
+    public boolean isSyncStalled() {
+        return SyncHealth.isStalled(behindSinceMs, System.currentTimeMillis(), loaderLastSuccessAgeSeconds);
+    }
+
+    /**
+     * Report that this instance answers requests but is no longer ingesting.
+     *
+     * <p>Deliberately does not touch the success/failure counters: the instance really is
+     * up, and during the 2026-07-31 stall it served queries in ~0.1 s throughout. Folding
+     * this into the failure count would corrupt the OK ratio, which measures availability.
+     * Call after {@link #reportTestSuccess(long)}, which resets the status to OK.
+     */
+    public void reportStalled() {
+        status = "STALLED";
+        logger.info("Test result: {} STALLED (lag {}, loader {})",
+                service.getServiceIri(), getSyncLagString(), getLoaderAgeString());
     }
 
     /**

--- a/src/main/java/ch/tkuhn/nanopub/monitor/ServerScanner.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/ServerScanner.java
@@ -365,12 +365,26 @@ public class ServerScanner implements ICode {
                         d.setVersion(headerValue(resp, "Nanopub-Query-Version"));
                         d.setNanopubCount(parseLongOrNull(headerValue(resp, "Nanopub-Query-Loaded-Nanopub-Count")));
                         d.setLoadedNanopubChecksum(headerValue(resp, "Nanopub-Query-Loaded-Nanopub-Checksum"));
+                        // Both counts come from the same response, so one request tells us how far
+                        // this instance trails its own registry — no cross-instance comparison, and
+                        // so still meaningful when every instance is equally behind. The loader-age
+                        // header is absent on instances predating it; the column stays empty there.
+                        d.updateSyncHealth(
+                                parseLongOrNull(headerValue(resp, "Nanopub-Query-Registry-Nanopub-Count")),
+                                parseLongOrNull(headerValue(resp, "Nanopub-Query-Loader-Last-Success-Age-Seconds")));
                         d.setTestInstance("true".equalsIgnoreCase(headerValue(resp, "Nanopub-Query-Registry-Test-Instance")));
                         String headerStatus = headerValue(resp, "Nanopub-Query-Status");
                         if (headerStatus == null || !headerStatus.equalsIgnoreCase("READY")) {
                             d.reportTestFailure("STATUS: " + (headerStatus == null ? "missing" : headerStatus));
                         } else {
                             d.reportTestSuccess(watch.getTime());
+                            // A stalled instance still reports READY and still answers quickly —
+                            // that is exactly why the 2026-07-31 stall went unnoticed for hours.
+                            // Overrides the status only after the success is recorded, so the OK
+                            // ratio keeps measuring availability.
+                            if (d.isSyncStalled()) {
+                                d.reportStalled();
+                            }
                         }
                     }
                 } catch (Exception ex) {

--- a/src/main/java/ch/tkuhn/nanopub/monitor/SyncHealth.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/SyncHealth.java
@@ -1,0 +1,112 @@
+package ch.tkuhn.nanopub.monitor;
+
+/**
+ * Sync-health arithmetic for nanopub-query instances: how far one trails its own
+ * registry, and whether it has stopped ingesting altogether.
+ *
+ * <p>These checks are deliberately <em>absolute</em>. The checksum consensus check
+ * compares instances against each other, so it can only see a problem while at least
+ * one of them is healthy — when every instance stalls together they agree perfectly
+ * and the fleet reads as all-clear. Comparing each instance against its own registry
+ * means agreement buys nothing.
+ *
+ * <p>The two signals are not redundant. The registry side of the lag is whatever the
+ * instance's most recent successful poll returned, so if polling itself is what broke,
+ * the loaded count and the registry count freeze together and the lag settles at a
+ * reassuring zero; only the loader age catches that. Conversely an instance that keeps
+ * polling but falls behind moves only the lag.
+ *
+ * <p>Static and state-free so it can be tested without constructing a
+ * {@link ServerData}, whose constructor performs geo-IP lookups.
+ */
+final class SyncHealth {
+
+    /**
+     * Loader age beyond which an instance counts as stalled. The loader polls every
+     * two seconds and stamps its timestamp even on idle "nothing to do" ticks, so a
+     * healthy instance stays near zero however quiet the registry is.
+     */
+    static final long LOADER_STALL_SECONDS = 300;
+
+    /**
+     * How long an instance may sit behind its registry before it counts as stalled.
+     * Generous because a nanopub published between the instance's registry poll and
+     * its batch landing shows up here as legitimate transient lag.
+     */
+    static final long BEHIND_GRACE_MS = 15 * 60 * 1000L;
+
+    private SyncHealth() {
+    }
+
+    /**
+     * How far an instance trails its registry.
+     *
+     * <p>Clamped at zero: the loaded count is bumped as each nanopub lands while the
+     * forwarded registry count only refreshes once per poll, so the loaded side can
+     * legitimately run ahead for a moment. That is not something to report as a
+     * negative lag.
+     *
+     * @param registryCount nanopubs the instance's registry reports holding, or null
+     * @param loadedCount   nanopubs the instance reports having loaded, or null
+     * @return the lag in nanopubs, or null if either count is unknown
+     */
+    static Long lag(Long registryCount, Long loadedCount) {
+        if (registryCount == null || loadedCount == null) {
+            return null;
+        }
+        return Math.max(0L, registryCount - loadedCount);
+    }
+
+    /**
+     * Renders a lag for the table cell.
+     *
+     * @param lag the lag in nanopubs, or null if unknown
+     * @return "in sync", "N behind", or "" when unknown
+     */
+    static String formatLag(Long lag) {
+        if (lag == null) {
+            return "";
+        }
+        if (lag == 0L) {
+            return "in sync";
+        }
+        return String.format("%,d behind", lag);
+    }
+
+    /**
+     * Renders a loader age for the table cell, at the coarsest useful precision.
+     *
+     * @param seconds seconds since the loader last completed a tick, or null if unknown
+     * @return e.g. "2s ago", "48m ago", "2h 04m ago", or "" when unknown
+     */
+    static String formatAge(Long seconds) {
+        if (seconds == null || seconds < 0) {
+            return "";
+        }
+        if (seconds < 60) {
+            return seconds + "s ago";
+        }
+        long minutes = seconds / 60;
+        if (minutes < 60) {
+            return minutes + "m ago";
+        }
+        return String.format("%dh %02dm ago", minutes / 60, minutes % 60);
+    }
+
+    /**
+     * Whether an instance should be reported as stalled: reachable and answering, but
+     * no longer keeping up with its registry.
+     *
+     * @param behindSinceMs   epoch millis when the instance was first seen behind, or null if level
+     * @param nowMs           current epoch millis
+     * @param loaderAgeSeconds seconds since the loader last completed a tick, or null if unknown
+     * @return true if the instance has been out of sync long enough to report
+     */
+    static boolean isStalled(Long behindSinceMs, long nowMs, Long loaderAgeSeconds) {
+        if (loaderAgeSeconds != null && loaderAgeSeconds > LOADER_STALL_SECONDS) {
+            return true;
+        }
+        return behindSinceMs != null && nowMs - behindSinceMs > BEHIND_GRACE_MS;
+    }
+
+}

--- a/src/test/java/ch/tkuhn/nanopub/monitor/SyncHealthTest.java
+++ b/src/test/java/ch/tkuhn/nanopub/monitor/SyncHealthTest.java
@@ -1,0 +1,83 @@
+package ch.tkuhn.nanopub.monitor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SyncHealthTest {
+
+    @Test
+    void lagIsUnknownUntilBothCountsArrive() {
+        // Unknown has to stay distinguishable from zero: an instance that has not been
+        // scanned yet must not be reported as in sync.
+        assertNull(SyncHealth.lag(null, 100L));
+        assertNull(SyncHealth.lag(100L, null));
+        assertNull(SyncHealth.lag(null, null));
+    }
+
+    @Test
+    void lagIsTheShortfallAgainstTheRegistry() {
+        assertEquals(0L, SyncHealth.lag(86605L, 86605L));
+        assertEquals(7L, SyncHealth.lag(86605L, 86598L));
+    }
+
+    @Test
+    void lagIsClampedWhenTheLoadedCountRunsAhead() {
+        // The loaded count is bumped per nanopub while the registry count refreshes once
+        // per poll, so the loaded side legitimately leads for a moment.
+        assertEquals(0L, SyncHealth.lag(86600L, 86605L));
+    }
+
+    @Test
+    void lagFormatting() {
+        assertEquals("", SyncHealth.formatLag(null));
+        assertEquals("in sync", SyncHealth.formatLag(0L));
+        assertEquals("7 behind", SyncHealth.formatLag(7L));
+        assertEquals("1,204 behind", SyncHealth.formatLag(1204L));
+    }
+
+    @Test
+    void ageFormatting() {
+        assertEquals("", SyncHealth.formatAge(null));
+        assertEquals("", SyncHealth.formatAge(-1L));
+        assertEquals("2s ago", SyncHealth.formatAge(2L));
+        assertEquals("59s ago", SyncHealth.formatAge(59L));
+        assertEquals("1m ago", SyncHealth.formatAge(60L));
+        assertEquals("48m ago", SyncHealth.formatAge(2880L));
+        assertEquals("1h 00m ago", SyncHealth.formatAge(3600L));
+        // The 2026-07-31 stall, at the point it was noticed.
+        assertEquals("2h 04m ago", SyncHealth.formatAge(7440L));
+    }
+
+    @Test
+    void aHealthyInstanceIsNotStalled() {
+        long now = 1_000_000L;
+        assertFalse(SyncHealth.isStalled(null, now, 2L));
+        // Unknown loader age must not by itself imply a stall — instances predating the
+        // header would all be flagged.
+        assertFalse(SyncHealth.isStalled(null, now, null));
+    }
+
+    @Test
+    void briefLagIsToleratedButSustainedLagIsNot() {
+        long now = 1_000_000_000L;
+        long justBehind = now - 60_000L;
+        assertFalse(SyncHealth.isStalled(justBehind, now, null));
+
+        long longBehind = now - SyncHealth.BEHIND_GRACE_MS - 1L;
+        assertTrue(SyncHealth.isStalled(longBehind, now, null));
+    }
+
+    @Test
+    void aDeadLoaderIsStalledEvenWhileTheLagStillReadsZero() {
+        // The failure mode the lag alone cannot see: when the registry poll is what
+        // broke, both counts freeze together and the lag settles at zero.
+        long now = 1_000_000_000L;
+        assertTrue(SyncHealth.isStalled(null, now, SyncHealth.LOADER_STALL_SECONDS + 1));
+        assertFalse(SyncHealth.isStalled(null, now, SyncHealth.LOADER_STALL_SECONDS));
+    }
+
+}


### PR DESCRIPTION
Closes the blind spot behind the 2026-07-31 stall. Mockup of the result: https://claude.ai/code/artifact/8d0e9bd1-1a94-4a7d-8d78-7932a47d6273

## The blind spot

The monitor compares instances **against each other** — it flags a loaded checksum that disagrees with the consensus. That only works while at least one instance is healthy. When every instance stalls together (a bad deploy, a shared upstream fault, one bug firing everywhere) they agree perfectly and the whole fleet reads as all-clear.

Even in the single-instance case it under-reported: during the stall, `query.knowledgepixels.com` sat seven nanopubs behind for over two hours while its Status column said **OK**, with only the checksum marked an outlier — which reads as cosmetic drift, not data loss.

## Two new columns

Both compare each instance against **its own registry**, so agreement between instances buys nothing.

- **Sync** — registry count minus loaded count. Both values already arrive in the same response (`Nanopub-Query-Registry-Nanopub-Count` and `Nanopub-Query-Loaded-Nanopub-Count`), so this costs no extra requests. Clamped at zero, because the loaded count is bumped per nanopub while the registry count refreshes once per poll and can briefly trail it.
- **Loader** — seconds since the loader last completed a tick, from `Nanopub-Query-Loader-Last-Success-Age-Seconds` (knowledgepixels/nanopub-query#149). Instances that don't send it leave the column empty, so this merges independently.

**They are not redundant.** The registry side of the lag is whatever the last successful poll returned, so if polling itself broke, both counts freeze together and the lag settles at a reassuring zero — only the loader age catches that. Conversely an instance that keeps polling but falls behind moves only the lag. `SyncHealthTest.aDeadLoaderIsStalledEvenWhileTheLagStillReadsZero` pins this.

## Status gains STALLED

An instance behind for more than 15 minutes, or whose loader hasn't ticked in 5, now reports `STALLED` rather than `OK`, and picks up the existing red styling.

Applied **after** `reportTestSuccess`, deliberately, so it doesn't touch the success/failure counters. A stalled instance genuinely is up — it served queries in ~0.1s throughout the incident — and folding this into the failure count would corrupt the OK ratio, which measures availability. `STALLED` is a distinct condition from `DOWN`/`INACCESSIBLE`: reachable, but not ingesting.

The 15-minute grace exists because a nanopub published between an instance's registry poll and its batch landing shows up as legitimate transient lag.

## Unchanged on purpose

The checksum consensus check stays. It catches something the sync columns cannot: silent divergence where the counts match but the content differs.

## Also

Sync lag, registry count and loader age are added to the `.csv` and `.json` outputs, so the nanopub-router and any other machine consumer see them too.

## Testing

`SyncHealthTest` covers the lag arithmetic (unknown vs zero, the clamp), both formatters, and the stall thresholds. The logic lives in a static, state-free `SyncHealth` so it can be tested without constructing a `ServerData`, whose constructor performs geo-IP lookups. 20 tests green.

Also verified the new `wicket:id`s in the row markup match the components added in `populateItem` — a mismatch there is a runtime failure, not a compile error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)