### PR TITLE
fix: initialize logger before eager singletons in static init

### DIFF
--- a/src/main/java/ch/tkuhn/nanopub/monitor/CsvTable.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/CsvTable.java
@@ -17,8 +17,8 @@ public class CsvTable implements SerializableSupplier<IResource> {
 
     private static final long serialVersionUID = 7196507056520414804L;
 
-    private static final CsvTable instance = new CsvTable();
     private static final Logger logger = LoggerFactory.getLogger(CsvTable.class);
+    private static final CsvTable instance = new CsvTable();
 
     /**
      * Get the singleton instance of CsvTable.

--- a/src/main/java/ch/tkuhn/nanopub/monitor/JsonStatus.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/JsonStatus.java
@@ -22,9 +22,9 @@ public class JsonStatus implements SerializableSupplier<IResource> {
 
     private static final long serialVersionUID = 1L;
 
-    private static final JsonStatus instance = new JsonStatus();
-    private static final Gson gson = new GsonBuilder().serializeNulls().create();
     private static final Logger logger = LoggerFactory.getLogger(JsonStatus.class);
+    private static final Gson gson = new GsonBuilder().serializeNulls().create();
+    private static final JsonStatus instance = new JsonStatus();
 
     public static JsonStatus instance() {
         return instance;

--- a/src/main/java/ch/tkuhn/nanopub/monitor/MonitorConf.java
+++ b/src/main/java/ch/tkuhn/nanopub/monitor/MonitorConf.java
@@ -12,8 +12,8 @@ import java.util.Properties;
  */
 public class MonitorConf {
 
-    private static final MonitorConf obj = new MonitorConf();
     private static final Logger logger = LoggerFactory.getLogger(MonitorConf.class);
+    private static final MonitorConf obj = new MonitorConf();
 
     /**
      * Get the singleton instance of the configuration.
@@ -33,14 +33,14 @@ public class MonitorConf {
         InputStream in = MonitorConf.class.getResourceAsStream(mainConfFile);
         if (in == null) {
             logger.error("Configuration file '{}' not found on classpath", mainConfFile);
-            System.exit(1);
+            throw new IllegalStateException("Configuration file '" + mainConfFile + "' not found on classpath");
         }
         try {
             conf.load(in);
             logger.info("Loaded configuration from '{}'", mainConfFile);
         } catch (IOException ex) {
             logger.error("Could not load configuration file '{}'", mainConfFile, ex);
-            System.exit(1);
+            throw new IllegalStateException("Could not load configuration file '" + mainConfFile + "'", ex);
         }
 
         String localConfFile = "local.conf.properties";
@@ -51,7 +51,7 @@ public class MonitorConf {
                 logger.info("Loaded local configuration overrides from '{}'", localConfFile);
             } catch (IOException ex) {
                 logger.error("Could not load local configuration file '{}'", localConfFile, ex);
-                System.exit(1);
+                throw new IllegalStateException("Could not load local configuration file '" + localConfFile + "'", ex);
             }
         } else {
             logger.debug("No local configuration file '{}' found, using defaults only", localConfFile);

--- a/src/test/java/ch/tkuhn/nanopub/monitor/MonitorConfTest.java
+++ b/src/test/java/ch/tkuhn/nanopub/monitor/MonitorConfTest.java
@@ -1,0 +1,37 @@
+package ch.tkuhn.nanopub.monitor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MonitorConfTest {
+
+    @Test
+    void get() {
+        MonitorConf conf = MonitorConf.get();
+        assertNotNull(conf);
+        assertSame(conf, MonitorConf.get());
+    }
+
+    @Test
+    void scanFreq() {
+        assertTrue(MonitorConf.get().getScanFreq() > 0);
+    }
+
+    @Test
+    void scanThreads() {
+        assertTrue(MonitorConf.get().getScanThreads() > 0);
+    }
+
+    @Test
+    void flagsAreReadable() {
+        MonitorConf conf = MonitorConf.get();
+        // No assertion on the values themselves, which are deployment choices;
+        // this only pins down that the properties are present and parseable.
+        conf.showMap();
+        conf.isGeoIpInfoEnabled();
+    }
+
+}


### PR DESCRIPTION
## Problem

The deployed app returned 500s on every page:

```
Caused by: java.lang.NullPointerException: Cannot invoke "org.slf4j.Logger.info(String, Object)"
  because "ch.tkuhn.nanopub.monitor.MonitorConf.logger" is null
	at ch.tkuhn.nanopub.monitor.MonitorConf.<init>(MonitorConf.java:40)
	at ch.tkuhn.nanopub.monitor.MonitorConf.<clinit>(MonitorConf.java:15)
```

`MonitorConf` declared its eager singleton before its logger:

```java
private static final MonitorConf obj = new MonitorConf();
private static final Logger logger = LoggerFactory.getLogger(MonitorConf.class);
```

Static fields initialize in declaration order, so the constructor ran with `logger` still `null`. The `logger.info` at line 40 is on the happy path, so this fired unconditionally on the first touch of the class (from `ServerScanner.initDaemon()` and `MonitorPage:47`). The NPE escaped `<clinit>` as `ExceptionInInitializerError`, and because a failed `<clinit>` marks the class permanently erroneous, every subsequent request got `NoClassDefFoundError: Could not initialize class MonitorConf`.

## Changes

- **`MonitorConf`** — declare the logger before the singleton.
- **`CsvTable`, `JsonStatus`** — same ordering fix. Both were latent: their private constructors are currently empty, so no NPE today, but they would break identically the moment anyone adds a log line or any init logic.
- **`MonitorConf`** — replace the three `System.exit(1)` calls with thrown `IllegalStateException`s carrying the same message (and wrapping the `IOException` where there is one). Exiting the JVM from `<clinit>` under Tomcat killed the whole servlet container instead of failing just this webapp.
- **`MonitorConfTest`** (new) — 4 tests covering singleton identity and property parsing. `getScanFreq() > 0` rather than `== 10`, so it tests the plumbing without pinning a deployment value.

## Verification

`./mvnw test` → 24/24 pass.

The new test was confirmed to actually catch the bug: temporarily reverting the `MonitorConf` field order makes all 4 new tests error with the exact production trace (`ExceptionInInitializerError` → `NullPointerException ... logger is null`) and fails the build. Nothing previously touched `MonitorConf`, which is why CI stayed green while the deployed app was down.

## Note on remaining behaviour

A genuine config failure (missing or unreadable `conf.properties`) still surfaces as `ExceptionInInitializerError` → `NoClassDefFoundError`, since the constructor runs from `<clinit>`. That shape is unchanged; what changes is that it is now only reachable on a real config problem, the cause chain names the file, and the container survives.

Not addressed here — CI tests on Java 21/23 while the `Dockerfile` builds on Temurin 25. Unrelated to this bug, but worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
